### PR TITLE
Macro PR to adapt all cards to use the proper externalLHEProducer 

### DIFF
--- a/Cards/MadGraph5_aMCatNLO/DY/DYGto2LG-1Jets_MLL-50_PTG-100to200_amcatnloFXFX-pythia8/DYGto2LG-1Jets_MLL-50_PTG-100to200_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYGto2LG-1Jets_MLL-50_PTG-100to200_amcatnloFXFX-pythia8/DYGto2LG-1Jets_MLL-50_PTG-100to200_amcatnloFXFX-pythia8.json
@@ -13,7 +13,7 @@
         "set run_card ptgmin 70.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat", "Filter/LHE_Gamma_Pt100to200_filter.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat", "Filter/LHE_Gamma_Pt100to200_filter.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYGto2LG-1Jets_MLL-50_PTG-10to50_amcatnloFXFX-pythia8/DYGto2LG-1Jets_MLL-50_PTG-10to50_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYGto2LG-1Jets_MLL-50_PTG-10to50_amcatnloFXFX-pythia8/DYGto2LG-1Jets_MLL-50_PTG-10to50_amcatnloFXFX-pythia8.json
@@ -13,7 +13,7 @@
         "set run_card ptgmin 10.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat", "Filter/LHE_Gamma_Pt0to50_filter.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat", "Filter/LHE_Gamma_Pt0to50_filter.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYGto2LG-1Jets_MLL-50_PTG-200_amcatnloFXFX-pythia8/DYGto2LG-1Jets_MLL-50_PTG-200_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYGto2LG-1Jets_MLL-50_PTG-200_amcatnloFXFX-pythia8/DYGto2LG-1Jets_MLL-50_PTG-200_amcatnloFXFX-pythia8.json
@@ -13,7 +13,7 @@
         "set run_card ptgmin 170.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat", "Filter/LHE_Gamma_Pt200_filter.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat", "Filter/LHE_Gamma_Pt200_filter.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYGto2LG-1Jets_MLL-50_PTG-50to100_amcatnloFXFX-pythia8/DYGto2LG-1Jets_MLL-50_PTG-50to100_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYGto2LG-1Jets_MLL-50_PTG-50to100_amcatnloFXFX-pythia8/DYGto2LG-1Jets_MLL-50_PTG-50to100_amcatnloFXFX-pythia8.json
@@ -13,7 +13,7 @@
         "set run_card ptgmin 20.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat", "Filter/LHE_Gamma_Pt50to100_filter.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat", "Filter/LHE_Gamma_Pt50to100_filter.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-2Jets_MLL-10to50_amcatnloFXFX-pythia8/DYto2L-2Jets_MLL-10to50_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-2Jets_MLL-10to50_amcatnloFXFX-pythia8/DYto2L-2Jets_MLL-10to50_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 10.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-2Jets_MLL-50_0J_amcatnloFXFX-pythia8/DYto2L-2Jets_MLL-50_0J_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-2Jets_MLL-50_0J_amcatnloFXFX-pythia8/DYto2L-2Jets_MLL-50_0J_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-2Jets_MLL-50_1J_amcatnloFXFX-pythia8/DYto2L-2Jets_MLL-50_1J_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-2Jets_MLL-50_1J_amcatnloFXFX-pythia8/DYto2L-2Jets_MLL-50_1J_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-2Jets_MLL-50_2J_amcatnloFXFX-pythia8/DYto2L-2Jets_MLL-50_2J_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-2Jets_MLL-50_2J_amcatnloFXFX-pythia8/DYto2L-2Jets_MLL-50_2J_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-2Jets_MLL-50_amcatnloFXFX-pythia8/DYto2L-2Jets_MLL-50_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-2Jets_MLL-50_amcatnloFXFX-pythia8/DYto2L-2Jets_MLL-50_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-10to50_madgraphMLM-pythia8/DYto2L-4Jets_MLL-10to50_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-10to50_madgraphMLM-pythia8/DYto2L-4Jets_MLL-10to50_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mmllmax 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_0J_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_0J_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_0J_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_0J_madgraphMLM-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card mmll 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_1J_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_1J_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_1J_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_1J_madgraphMLM-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card mmll 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_2J_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_2J_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_2J_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_2J_madgraphMLM-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card mmll 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_3J_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_3J_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_3J_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_3J_madgraphMLM-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card mmll 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_4J_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_4J_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_4J_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_4J_madgraphMLM-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card mmll 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/DY/DYto2L-4Jets_MLL-50_madgraphMLM-pythia8/DYto2L-4Jets_MLL-50_madgraphMLM-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card mmll 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/NewTests/QCD-4Jets_HT-40_madgraphMLM-pythia8/QCD-4Jets_HT-40_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/NewTests/QCD-4Jets_HT-40_madgraphMLM-pythia8/QCD-4Jets_HT-40_madgraphMLM-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card htjmin 40"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/NewTests/QCD-5Jets_HT-40_madgraphMLM-pythia8/QCD-5Jets_HT-40_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/NewTests/QCD-5Jets_HT-40_madgraphMLM-pythia8/QCD-5Jets_HT-40_madgraphMLM-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card htjmin 40"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/NewTests/TWto2L2Nu-DR1_amcatnlo-pythia8/TWto2L2Nu-DR1_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/NewTests/TWto2L2Nu-DR1_amcatnlo-pythia8/TWto2L2Nu-DR1_amcatnlo-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card istr 1"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/NewTests/TWto2L2Nu-nonCKM-DR1_amcatnlo-pythia8/TWto2L2Nu-nonCKM-DR1_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/NewTests/TWto2L2Nu-nonCKM-DR1_amcatnlo-pythia8/TWto2L2Nu-nonCKM-DR1_amcatnlo-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-100to200_madgraphMLM-pythia8/G-4Jets_HT-100to200_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-100to200_madgraphMLM-pythia8/G-4Jets_HT-100to200_madgraphMLM-pythia8.json
@@ -13,7 +13,7 @@
         "set run_card htjmax 200.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-200to400_madgraphMLM-pythia8/G-4Jets_HT-200to400_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-200to400_madgraphMLM-pythia8/G-4Jets_HT-200to400_madgraphMLM-pythia8.json
@@ -13,7 +13,7 @@
         "set run_card htjmax 400.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-400to600_madgraphMLM-pythia8/G-4Jets_HT-400to600_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-400to600_madgraphMLM-pythia8/G-4Jets_HT-400to600_madgraphMLM-pythia8.json
@@ -13,7 +13,7 @@
         "set run_card htjmax 600.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-40to70_madgraphMLM-pythia8/G-4Jets_HT-40to70_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-40to70_madgraphMLM-pythia8/G-4Jets_HT-40to70_madgraphMLM-pythia8.json
@@ -13,7 +13,7 @@
         "set run_card htjmax 70.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-600_madgraphMLM-pythia8/G-4Jets_HT-600_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-600_madgraphMLM-pythia8/G-4Jets_HT-600_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmin 600.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-70to100_madgraphMLM-pythia8/G-4Jets_HT-70to100_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/Others/G-4Jets_HT-70to100_madgraphMLM-pythia8/G-4Jets_HT-70to100_madgraphMLM-pythia8.json
@@ -13,7 +13,7 @@
         "set run_card htjmax 100.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/Others/VVto2L2Nu-1Jets-4FS_MLL-10to50_amcatnloFXFX-pythia8/VVto2L2Nu-1Jets-4FS_MLL-10to50_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/Others/VVto2L2Nu-1Jets-4FS_MLL-10to50_amcatnloFXFX-pythia8/VVto2L2Nu-1Jets-4FS_MLL-10to50_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll 10"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/Others/VVto2L2Nu-1Jets-4FS_MLL-50_amcatnloFXFX-pythia8/VVto2L2Nu-1Jets-4FS_MLL-50_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/Others/VVto2L2Nu-1Jets-4FS_MLL-50_amcatnloFXFX-pythia8/VVto2L2Nu-1Jets-4FS_MLL-50_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll 50"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/Others/VVto2L2Nu-1Jets-4FS_amcatnloFXFX-pythia8/VVto2L2Nu-1Jets-4FS_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/Others/VVto2L2Nu-1Jets-4FS_amcatnloFXFX-pythia8/VVto2L2Nu-1Jets-4FS_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 4"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-1000to1200_madgraphMLM-pythia8/QCD-4Jets_HT-1000to1200_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-1000to1200_madgraphMLM-pythia8/QCD-4Jets_HT-1000to1200_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 1200"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-100to200_madgraphMLM-pythia8/QCD-4Jets_HT-100to200_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-100to200_madgraphMLM-pythia8/QCD-4Jets_HT-100to200_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 200"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-1200to1500_madgraphMLM-pythia8/QCD-4Jets_HT-1200to1500_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-1200to1500_madgraphMLM-pythia8/QCD-4Jets_HT-1200to1500_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 1500"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-1500to2000_madgraphMLM-pythia8/QCD-4Jets_HT-1500to2000_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-1500to2000_madgraphMLM-pythia8/QCD-4Jets_HT-1500to2000_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 2000"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-2000_madgraphMLM-pythia8/QCD-4Jets_HT-2000_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-2000_madgraphMLM-pythia8/QCD-4Jets_HT-2000_madgraphMLM-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card htjmin 2000"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-200to400_madgraphMLM-pythia8/QCD-4Jets_HT-200to400_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-200to400_madgraphMLM-pythia8/QCD-4Jets_HT-200to400_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 400"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-400to600_madgraphMLM-pythia8/QCD-4Jets_HT-400to600_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-400to600_madgraphMLM-pythia8/QCD-4Jets_HT-400to600_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 600"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-40to70_madgraphMLM-pythia8/QCD-4Jets_HT-40to70_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-40to70_madgraphMLM-pythia8/QCD-4Jets_HT-40to70_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 70"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-600to800_madgraphMLM-pythia8/QCD-4Jets_HT-600to800_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-600to800_madgraphMLM-pythia8/QCD-4Jets_HT-600to800_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 800"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-70to100_madgraphMLM-pythia8/QCD-4Jets_HT-70to100_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-70to100_madgraphMLM-pythia8/QCD-4Jets_HT-70to100_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 100"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-800to1000_madgraphMLM-pythia8/QCD-4Jets_HT-800to1000_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCD-4Jets_HT-800to1000_madgraphMLM-pythia8/QCD-4Jets_HT-800to1000_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 1000"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-1000to1500_madgraphMLM-pythia8/QCDB-4Jets_HT-1000to1500_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-1000to1500_madgraphMLM-pythia8/QCDB-4Jets_HT-1000to1500_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 1500"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-100to200_madgraphMLM-pythia8/QCDB-4Jets_HT-100to200_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-100to200_madgraphMLM-pythia8/QCDB-4Jets_HT-100to200_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 200"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-1500to2000_madgraphMLM-pythia8/QCDB-4Jets_HT-1500to2000_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-1500to2000_madgraphMLM-pythia8/QCDB-4Jets_HT-1500to2000_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 2000"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-2000_madgraphMLM-pythia8/QCDB-4Jets_HT-2000_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-2000_madgraphMLM-pythia8/QCDB-4Jets_HT-2000_madgraphMLM-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card htjmin 2000"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-200to400_madgraphMLM-pythia8/QCDB-4Jets_HT-200to400_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-200to400_madgraphMLM-pythia8/QCDB-4Jets_HT-200to400_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 400"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-400to600_madgraphMLM-pythia8/QCDB-4Jets_HT-400to600_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-400to600_madgraphMLM-pythia8/QCDB-4Jets_HT-400to600_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 600"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-40to100_madgraphMLM-pythia8/QCDB-4Jets_HT-40to100_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-40to100_madgraphMLM-pythia8/QCDB-4Jets_HT-40to100_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 100"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-600to800_madgraphMLM-pythia8/QCDB-4Jets_HT-600to800_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-600to800_madgraphMLM-pythia8/QCDB-4Jets_HT-600to800_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 800"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-800to1000_madgraphMLM-pythia8/QCDB-4Jets_HT-800to1000_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/QCD/QCDB-4Jets_HT-800to1000_madgraphMLM-pythia8/QCDB-4Jets_HT-800to1000_madgraphMLM-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card htjmax 1000"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/SingleT/TBQ2L_amcatnlo-pythia8/TBQ2L_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/SingleT/TBQ2L_amcatnlo-pythia8/TBQ2L_amcatnlo-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/SingleT/TBQG_amcatnlo-pythia8/TBQG_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/SingleT/TBQG_amcatnlo-pythia8/TBQG_amcatnlo-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/SingleT/TBbartoLplusNuBbar-4FS-s-channel_TuneCP5_13p6TeV_amcatnlo-pythia8/TBbartoLplusNuBbar-4FS-s-channel_TuneCP5_13p6TeV_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/SingleT/TBbartoLplusNuBbar-4FS-s-channel_TuneCP5_13p6TeV_amcatnlo-pythia8/TBbartoLplusNuBbar-4FS-s-channel_TuneCP5_13p6TeV_amcatnlo-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DR1_amcatnlo-pythia8/TWto2L2Nu-DR1_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DR1_amcatnlo-pythia8/TWto2L2Nu-DR1_amcatnlo-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DR2_amcatnlo-pythia8/TWto2L2Nu-DR2_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DR2_amcatnlo-pythia8/TWto2L2Nu-DR2_amcatnlo-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DS-FS-BW_amcatnlo-pythia8/TWto2L2Nu-DS-FS-BW_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DS-FS-BW_amcatnlo-pythia8/TWto2L2Nu-DS-FS-BW_amcatnlo-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DS-FS_amcatnlo-pythia8/TWto2L2Nu-DS-FS_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DS-FS_amcatnlo-pythia8/TWto2L2Nu-DS-FS_amcatnlo-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DS-IS-BW_amcatnlo-pythia8/TWto2L2Nu-DS-IS-BW_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DS-IS-BW_amcatnlo-pythia8/TWto2L2Nu-DS-IS-BW_amcatnlo-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DS-IS_amcatnlo-pythia8/TWto2L2Nu-DS-IS_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/SingleT/TWto2L2Nu-DS-IS_amcatnlo-pythia8/TWto2L2Nu-DS-IS_amcatnlo-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/SingleT/TbarBtoLminusNuB-4FS-s-channel_TuneCP5_13p6TeV_amcatnlo-pythia8/TbarBtoLminusNuB-4FS-s-channel_TuneCP5_13p6TeV_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/SingleT/TbarBtoLminusNuB-4FS-s-channel_TuneCP5_13p6TeV_amcatnlo-pythia8/TbarBtoLminusNuB-4FS-s-channel_TuneCP5_13p6TeV_amcatnlo-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTLL-1Jets_MLL-10to50_amcatnloFXFX-pythia8/TTLL-1Jets_MLL-10to50_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTLL-1Jets_MLL-10to50_amcatnloFXFX-pythia8/TTLL-1Jets_MLL-10to50_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 10.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTLL-1Jets_MLL-1to4_amcatnloFXFX-pythia8/TTLL-1Jets_MLL-1to4_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTLL-1Jets_MLL-1to4_amcatnloFXFX-pythia8/TTLL-1Jets_MLL-1to4_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 1.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTLL-1Jets_MLL-4to10_amcatnloFXFX-pythia8/TTLL-1Jets_MLL-4to10_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTLL-1Jets_MLL-4to10_amcatnloFXFX-pythia8/TTLL-1Jets_MLL-4to10_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 4.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTLL-1Jets_MLL-50_amcatnloFXFX-pythia8/TTLL-1Jets_MLL-50_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTLL-1Jets_MLL-50_amcatnloFXFX-pythia8/TTLL-1Jets_MLL-50_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTLL_MLL-10to50_amcatnlo-pythia8/TTLL_MLL-10to50_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTLL_MLL-10to50_amcatnlo-pythia8/TTLL_MLL-10to50_amcatnlo-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 10.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTLL_MLL-1to4_amcatnlo-pythia8/TTLL_MLL-1to4_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTLL_MLL-1to4_amcatnlo-pythia8/TTLL_MLL-1to4_amcatnlo-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 1.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTLL_MLL-4to10_amcatnlo-pythia8/TTLL_MLL-4to10_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTLL_MLL-4to10_amcatnlo-pythia8/TTLL_MLL-4to10_amcatnlo-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 4.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTLL_MLL-4to50_amcatnlo-pythia8/TTLL_MLL-4to50_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTLL_MLL-4to50_amcatnlo-pythia8/TTLL_MLL-4to50_amcatnlo-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 4.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTLL_MLL-50_amcatnlo-pythia8/TTLL_MLL-50_amcatnlo-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTLL_MLL-50_amcatnlo-pythia8/TTLL_MLL-50_amcatnlo-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnlo-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnlo-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTLNu-1Jets_amcatnloFXFX-pythia8/TTLNu-1Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTLNu-1Jets_amcatnloFXFX-pythia8/TTLNu-1Jets_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 20"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTNuNu-1Jets_amcatnloFXFX-pythia8/TTNuNu-1Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTNuNu-1Jets_amcatnloFXFX-pythia8/TTNuNu-1Jets_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 20"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTW-WtoQQ-1Jets_amcatnloFXFX-pythia8/TTW-WtoQQ-1Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTW-WtoQQ-1Jets_amcatnloFXFX-pythia8/TTW-WtoQQ-1Jets_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 20"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTZ-ZtoQQ-1Jets_amcatnloFXFX-pythia8/TTZ-ZtoQQ-1Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTZ-ZtoQQ-1Jets_amcatnloFXFX-pythia8/TTZ-ZtoQQ-1Jets_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 20"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-3Jets_madgraphMLM-pythia8/TTto2L2Nu-3Jets_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-3Jets_madgraphMLM-pythia8/TTto2L2Nu-3Jets_madgraphMLM-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-3Jets_madgraphMLM-pythia8/TTto4Q-3Jets_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-3Jets_madgraphMLM-pythia8/TTto4Q-3Jets_madgraphMLM-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-3Jets_madgraphMLM-pythia8/TTtoLminusNu2Q-3Jets_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-3Jets_madgraphMLM-pythia8/TTtoLminusNu2Q-3Jets_madgraphMLM-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-3Jets_madgraphMLM-pythia8/TTtoLplusNu2Q-3Jets_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-3Jets_madgraphMLM-pythia8/TTtoLplusNu2Q-3Jets_madgraphMLM-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/VBF/VBFto2L_MLL-50_madgraph-pythia8/VBFto2L_MLL-50_madgraph-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/VBF/VBFto2L_MLL-50_madgraph-pythia8/VBFto2L_MLL-50_madgraph-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mmll 50.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraph-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraph-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/VBF/VBFto2Nu_madgraph-pythia8/VBFto2Nu_madgraph-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/VBF/VBFto2Nu_madgraph-pythia8/VBFto2Nu_madgraph-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card mmjj 100.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraph-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraph-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/VBF/VBFtoG_madgraph-pythia8/VBFtoG_madgraph-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/VBF/VBFtoG_madgraph-pythia8/VBFtoG_madgraph-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mmjj 100.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraph-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraph-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/VBF/VBFtoLNu_madgraph-pythia8/VBFtoLNu_madgraph-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/VBF/VBFtoLNu_madgraph-pythia8/VBFtoLNu_madgraph-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card mmjj 100.0"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraph-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraph-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/W/WtoLNu-2Jets_0J_amcatnloFXFX-pythia8/WtoLNu-2Jets_0J_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/W/WtoLNu-2Jets_0J_amcatnloFXFX-pythia8/WtoLNu-2Jets_0J_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 10"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/W/WtoLNu-2Jets_1J_amcatnloFXFX-pythia8/WtoLNu-2Jets_1J_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/W/WtoLNu-2Jets_1J_amcatnloFXFX-pythia8/WtoLNu-2Jets_1J_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 10"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/W/WtoLNu-2Jets_2J_amcatnloFXFX-pythia8/WtoLNu-2Jets_2J_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/W/WtoLNu-2Jets_2J_amcatnloFXFX-pythia8/WtoLNu-2Jets_2J_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 10"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/W/WtoLNu-2Jets_amcatnloFXFX-pythia8/WtoLNu-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/W/WtoLNu-2Jets_amcatnloFXFX-pythia8/WtoLNu-2Jets_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 10"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_0J_madgraphMLM-pythia8/WtoLNu-4Jets_0J_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_0J_madgraphMLM-pythia8/WtoLNu-4Jets_0J_madgraphMLM-pythia8.json
@@ -9,7 +9,7 @@
     "model_params": "massW.dat",
     "model_params_user": [],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_1J_madgraphMLM-pythia8/WtoLNu-4Jets_1J_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_1J_madgraphMLM-pythia8/WtoLNu-4Jets_1J_madgraphMLM-pythia8.json
@@ -9,7 +9,7 @@
     "model_params": "massW.dat",
     "model_params_user": [],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_2J_madgraphMLM-pythia8/WtoLNu-4Jets_2J_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_2J_madgraphMLM-pythia8/WtoLNu-4Jets_2J_madgraphMLM-pythia8.json
@@ -9,7 +9,7 @@
     "model_params": "massW.dat",
     "model_params_user": [],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_3J_madgraphMLM-pythia8/WtoLNu-4Jets_3J_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_3J_madgraphMLM-pythia8/WtoLNu-4Jets_3J_madgraphMLM-pythia8.json
@@ -9,7 +9,7 @@
     "model_params": "massW.dat",
     "model_params_user": [],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_4J_madgraphMLM-pythia8/WtoLNu-4Jets_4J_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_4J_madgraphMLM-pythia8/WtoLNu-4Jets_4J_madgraphMLM-pythia8.json
@@ -9,7 +9,7 @@
     "model_params": "massW.dat",
     "model_params_user": [],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_madgraphMLM-pythia8/WtoLNu-4Jets_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/W/WtoLNu-4Jets_madgraphMLM-pythia8/WtoLNu-4Jets_madgraphMLM-pythia8.json
@@ -9,7 +9,7 @@
     "model_params": "massW.dat",
     "model_params_user": [],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/WW/WWto4Q-1Jets-4FS_amcatnloFXFX-pythia8/WWto4Q-1Jets-4FS_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/WW/WWto4Q-1Jets-4FS_amcatnloFXFX-pythia8/WWto4Q-1Jets-4FS_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 15"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/WW/WWtoLNu2Q-1Jets-4FS_amcatnloFXFX-pythia8/WWtoLNu2Q-1Jets-4FS_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/WW/WWtoLNu2Q-1Jets-4FS_amcatnloFXFX-pythia8/WWtoLNu2Q-1Jets-4FS_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 15"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/WZ/WZto3LNu-1Jets-4FS_amcatnloFXFX-pythia8/WZto3LNu-1Jets-4FS_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/WZ/WZto3LNu-1Jets-4FS_amcatnloFXFX-pythia8/WZto3LNu-1Jets-4FS_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 4"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/WZ/WZto4Q-1Jets-4FS_amcatnloFXFX-pythia8/WZto4Q-1Jets-4FS_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/WZ/WZto4Q-1Jets-4FS_amcatnloFXFX-pythia8/WZto4Q-1Jets-4FS_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 15"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/WZ/WZtoL3Nu-1Jets-4FS_amcatnloFXFX-pythia8/WZtoL3Nu-1Jets-4FS_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/WZ/WZtoL3Nu-1Jets-4FS_amcatnloFXFX-pythia8/WZtoL3Nu-1Jets-4FS_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 15"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/WZ/WZtoLNu2Q-1Jets-4FS_amcatnloFXFX-pythia8/WZtoLNu2Q-1Jets-4FS_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/WZ/WZtoLNu2Q-1Jets-4FS_amcatnloFXFX-pythia8/WZtoLNu2Q-1Jets-4FS_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 15"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/Z/Zto2Nu-4Jets_madgraphMLM-pythia8/Zto2Nu-4Jets_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/Z/Zto2Nu-4Jets_madgraphMLM-pythia8/Zto2Nu-4Jets_madgraphMLM-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/madgraphMLM-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/ZZ/ZZto2L2Q-1Jets_amcatnloFXFX-pythia8/ZZto2L2Q-1Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/ZZ/ZZto2L2Q-1Jets_amcatnloFXFX-pythia8/ZZto2L2Q-1Jets_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 4"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/ZZ/ZZto2Nu2Q-1Jets_amcatnloFXFX-pythia8/ZZto2Nu2Q-1Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/ZZ/ZZto2Nu2Q-1Jets_amcatnloFXFX-pythia8/ZZto2Nu2Q-1Jets_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 15"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/ZZ/ZZto4L-1Jets_amcatnloFXFX-pythia8/ZZto4L-1Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/ZZ/ZZto4L-1Jets_amcatnloFXFX-pythia8/ZZto4L-1Jets_amcatnloFXFX-pythia8.json
@@ -12,7 +12,7 @@
         "set run_card mll_sf 4"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/MadGraph5_aMCatNLO/ZZ/ZZto4Q-1Jets_amcatnloFXFX-pythia8/ZZto4Q-1Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/ZZ/ZZto4Q-1Jets_amcatnloFXFX-pythia8/ZZto4Q-1Jets_amcatnloFXFX-pythia8.json
@@ -11,7 +11,7 @@
         "set run_card ptj 15"
     ],
     "model_params_vars": {},
-    "fragment": ["Generator/ExternalLHEProducer.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2E_MLL-10to50_powheg-pythia8/DYto2E_MLL-10to50_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2E_MLL-10to50_powheg-pythia8/DYto2E_MLL-10to50_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2E_MLL-120to200_powheg-pythia8/DYto2E_MLL-120to200_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2E_MLL-120to200_powheg-pythia8/DYto2E_MLL-120to200_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2E_MLL-1500to2500_powheg-pythia8/DYto2E_MLL-1500to2500_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2E_MLL-1500to2500_powheg-pythia8/DYto2E_MLL-1500to2500_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2E_MLL-200to400_powheg-pythia8/DYto2E_MLL-200to400_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2E_MLL-200to400_powheg-pythia8/DYto2E_MLL-200to400_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2E_MLL-2500to4000_powheg-pythia8/DYto2E_MLL-2500to4000_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2E_MLL-2500to4000_powheg-pythia8/DYto2E_MLL-2500to4000_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2E_MLL-4000to6000_powheg-pythia8/DYto2E_MLL-4000to6000_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2E_MLL-4000to6000_powheg-pythia8/DYto2E_MLL-4000to6000_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2E_MLL-400to800_powheg-pythia8/DYto2E_MLL-400to800_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2E_MLL-400to800_powheg-pythia8/DYto2E_MLL-400to800_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2E_MLL-50to120_powheg-pythia8/DYto2E_MLL-50to120_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2E_MLL-50to120_powheg-pythia8/DYto2E_MLL-50to120_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2E_MLL-6000_powheg-pythia8/DYto2E_MLL-6000_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2E_MLL-6000_powheg-pythia8/DYto2E_MLL-6000_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2E_MLL-800to1500_powheg-pythia8/DYto2E_MLL-800to1500_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2E_MLL-800to1500_powheg-pythia8/DYto2E_MLL-800to1500_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Mu_MLL-10to50_powheg-pythia8/DYto2Mu_MLL-10to50_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Mu_MLL-10to50_powheg-pythia8/DYto2Mu_MLL-10to50_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Mu_MLL-120to200_powheg-pythia8/DYto2Mu_MLL-120to200_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Mu_MLL-120to200_powheg-pythia8/DYto2Mu_MLL-120to200_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Mu_MLL-1500to2500_powheg-pythia8/DYto2Mu_MLL-1500to2500_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Mu_MLL-1500to2500_powheg-pythia8/DYto2Mu_MLL-1500to2500_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Mu_MLL-200to400_powheg-pythia8/DYto2Mu_MLL-200to400_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Mu_MLL-200to400_powheg-pythia8/DYto2Mu_MLL-200to400_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Mu_MLL-2500to4000_powheg-pythia8/DYto2Mu_MLL-2500to4000_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Mu_MLL-2500to4000_powheg-pythia8/DYto2Mu_MLL-2500to4000_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Mu_MLL-4000to6000_powheg-pythia8/DYto2Mu_MLL-4000to6000_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Mu_MLL-4000to6000_powheg-pythia8/DYto2Mu_MLL-4000to6000_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Mu_MLL-400to800_powheg-pythia8/DYto2Mu_MLL-400to800_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Mu_MLL-400to800_powheg-pythia8/DYto2Mu_MLL-400to800_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Mu_MLL-50to120_powheg-pythia8/DYto2Mu_MLL-50to120_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Mu_MLL-50to120_powheg-pythia8/DYto2Mu_MLL-50to120_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Mu_MLL-6000_powheg-pythia8/DYto2Mu_MLL-6000_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Mu_MLL-6000_powheg-pythia8/DYto2Mu_MLL-6000_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Mu_MLL-800to1500_powheg-pythia8/DYto2Mu_MLL-800to1500_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Mu_MLL-800to1500_powheg-pythia8/DYto2Mu_MLL-800to1500_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Tau_MLL-10to50_powheg-pythia8/DYto2Tau_MLL-10to50_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Tau_MLL-10to50_powheg-pythia8/DYto2Tau_MLL-10to50_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Tau_MLL-120to200_powheg-pythia8/DYto2Tau_MLL-120to200_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Tau_MLL-120to200_powheg-pythia8/DYto2Tau_MLL-120to200_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Tau_MLL-1500to2500_powheg-pythia8/DYto2Tau_MLL-1500to2500_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Tau_MLL-1500to2500_powheg-pythia8/DYto2Tau_MLL-1500to2500_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Tau_MLL-200to400_powheg-pythia8/DYto2Tau_MLL-200to400_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Tau_MLL-200to400_powheg-pythia8/DYto2Tau_MLL-200to400_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Tau_MLL-2500to4000_powheg-pythia8/DYto2Tau_MLL-2500to4000_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Tau_MLL-2500to4000_powheg-pythia8/DYto2Tau_MLL-2500to4000_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Tau_MLL-4000to6000_powheg-pythia8/DYto2Tau_MLL-4000to6000_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Tau_MLL-4000to6000_powheg-pythia8/DYto2Tau_MLL-4000to6000_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Tau_MLL-400to800_powheg-pythia8/DYto2Tau_MLL-400to800_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Tau_MLL-400to800_powheg-pythia8/DYto2Tau_MLL-400to800_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Tau_MLL-50to120_powheg-pythia8/DYto2Tau_MLL-50to120_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Tau_MLL-50to120_powheg-pythia8/DYto2Tau_MLL-50to120_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Tau_MLL-6000_powheg-pythia8/DYto2Tau_MLL-6000_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Tau_MLL-6000_powheg-pythia8/DYto2Tau_MLL-6000_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/DY/DYto2Tau_MLL-800to1500_powheg-pythia8/DYto2Tau_MLL-800to1500_powheg-pythia8.json
+++ b/Cards/Powheg/DY/DYto2Tau_MLL-800to1500_powheg-pythia8/DYto2Tau_MLL-800to1500_powheg-pythia8.json
@@ -11,7 +11,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto2L2Nu_DS_powheg-pythia8/TWminusto2L2Nu_DS_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto2L2Nu_DS_powheg-pythia8/TWminusto2L2Nu_DS_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto2L2Nu_Hdamp-158_powheg-pythia8/TWminusto2L2Nu_Hdamp-158_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto2L2Nu_Hdamp-158_powheg-pythia8/TWminusto2L2Nu_Hdamp-158_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto2L2Nu_Hdamp-418_powheg-pythia8/TWminusto2L2Nu_Hdamp-418_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto2L2Nu_Hdamp-418_powheg-pythia8/TWminusto2L2Nu_Hdamp-418_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto2L2Nu_MT-169p5_powheg-pythia8/TWminusto2L2Nu_MT-169p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto2L2Nu_MT-169p5_powheg-pythia8/TWminusto2L2Nu_MT-169p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto2L2Nu_MT-171p5_powheg-pythia8/TWminusto2L2Nu_MT-171p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto2L2Nu_MT-171p5_powheg-pythia8/TWminusto2L2Nu_MT-171p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto2L2Nu_MT-173p5_powheg-pythia8/TWminusto2L2Nu_MT-173p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto2L2Nu_MT-173p5_powheg-pythia8/TWminusto2L2Nu_MT-173p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto2L2Nu_MT-175p5_powheg-pythia8/TWminusto2L2Nu_MT-175p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto2L2Nu_MT-175p5_powheg-pythia8/TWminusto2L2Nu_MT-175p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto2L2Nu_powheg-pythia8/TWminusto2L2Nu_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto2L2Nu_powheg-pythia8/TWminusto2L2Nu_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto4Q_DS_powheg-pythia8/TWminusto4Q_DS_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto4Q_DS_powheg-pythia8/TWminusto4Q_DS_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto4Q_Hdamp-158_powheg-pythia8/TWminusto4Q_Hdamp-158_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto4Q_Hdamp-158_powheg-pythia8/TWminusto4Q_Hdamp-158_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto4Q_Hdamp-418_powheg-pythia8/TWminusto4Q_Hdamp-418_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto4Q_Hdamp-418_powheg-pythia8/TWminusto4Q_Hdamp-418_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto4Q_MT-169p5_powheg-pythia8/TWminusto4Q_MT-169p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto4Q_MT-169p5_powheg-pythia8/TWminusto4Q_MT-169p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto4Q_MT-171p5_powheg-pythia8/TWminusto4Q_MT-171p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto4Q_MT-171p5_powheg-pythia8/TWminusto4Q_MT-171p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto4Q_MT-173p5_powheg-pythia8/TWminusto4Q_MT-173p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto4Q_MT-173p5_powheg-pythia8/TWminusto4Q_MT-173p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto4Q_MT-175p5_powheg-pythia8/TWminusto4Q_MT-175p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto4Q_MT-175p5_powheg-pythia8/TWminusto4Q_MT-175p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminusto4Q_powheg-pythia8/TWminusto4Q_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminusto4Q_powheg-pythia8/TWminusto4Q_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminustoLNu2Q_DS_powheg-pythia8/TWminustoLNu2Q_DS_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminustoLNu2Q_DS_powheg-pythia8/TWminustoLNu2Q_DS_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminustoLNu2Q_Hdamp-158_powheg-pythia8/TWminustoLNu2Q_Hdamp-158_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminustoLNu2Q_Hdamp-158_powheg-pythia8/TWminustoLNu2Q_Hdamp-158_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminustoLNu2Q_Hdamp-418_powheg-pythia8/TWminustoLNu2Q_Hdamp-418_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminustoLNu2Q_Hdamp-418_powheg-pythia8/TWminustoLNu2Q_Hdamp-418_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminustoLNu2Q_MT-169p5_powheg-pythia8/TWminustoLNu2Q_MT-169p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminustoLNu2Q_MT-169p5_powheg-pythia8/TWminustoLNu2Q_MT-169p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminustoLNu2Q_MT-171p5_powheg-pythia8/TWminustoLNu2Q_MT-171p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminustoLNu2Q_MT-171p5_powheg-pythia8/TWminustoLNu2Q_MT-171p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminustoLNu2Q_MT-173p5_powheg-pythia8/TWminustoLNu2Q_MT-173p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminustoLNu2Q_MT-173p5_powheg-pythia8/TWminustoLNu2Q_MT-173p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminustoLNu2Q_MT-175p5_powheg-pythia8/TWminustoLNu2Q_MT-175p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminustoLNu2Q_MT-175p5_powheg-pythia8/TWminustoLNu2Q_MT-175p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TWminustoLNu2Q_powheg-pythia8/TWminustoLNu2Q_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TWminustoLNu2Q_powheg-pythia8/TWminustoLNu2Q_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto2L2Nu_DS_powheg-pythia8/TbarWplusto2L2Nu_DS_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto2L2Nu_DS_powheg-pythia8/TbarWplusto2L2Nu_DS_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto2L2Nu_Hdamp-158_powheg-pythia8/TbarWplusto2L2Nu_Hdamp-158_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto2L2Nu_Hdamp-158_powheg-pythia8/TbarWplusto2L2Nu_Hdamp-158_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto2L2Nu_Hdamp-418_powheg-pythia8/TbarWplusto2L2Nu_Hdamp-418_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto2L2Nu_Hdamp-418_powheg-pythia8/TbarWplusto2L2Nu_Hdamp-418_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto2L2Nu_MT-169p5_powheg-pythia8/TbarWplusto2L2Nu_MT-169p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto2L2Nu_MT-169p5_powheg-pythia8/TbarWplusto2L2Nu_MT-169p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto2L2Nu_MT-171p5_powheg-pythia8/TbarWplusto2L2Nu_MT-171p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto2L2Nu_MT-171p5_powheg-pythia8/TbarWplusto2L2Nu_MT-171p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto2L2Nu_MT-173p5_powheg-pythia8/TbarWplusto2L2Nu_MT-173p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto2L2Nu_MT-173p5_powheg-pythia8/TbarWplusto2L2Nu_MT-173p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto2L2Nu_MT-175p5_powheg-pythia8/TbarWplusto2L2Nu_MT-175p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto2L2Nu_MT-175p5_powheg-pythia8/TbarWplusto2L2Nu_MT-175p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto2L2Nu_powheg-pythia8/TbarWplusto2L2Nu_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto2L2Nu_powheg-pythia8/TbarWplusto2L2Nu_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto4Q_DS_powheg-pythia8/TbarWplusto4Q_DS_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto4Q_DS_powheg-pythia8/TbarWplusto4Q_DS_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto4Q_Hdamp-158_powheg-pythia8/TbarWplusto4Q_Hdamp-158_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto4Q_Hdamp-158_powheg-pythia8/TbarWplusto4Q_Hdamp-158_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto4Q_Hdamp-418_powheg-pythia8/TbarWplusto4Q_Hdamp-418_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto4Q_Hdamp-418_powheg-pythia8/TbarWplusto4Q_Hdamp-418_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto4Q_MT-169p5_powheg-pythia8/TbarWplusto4Q_MT-169p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto4Q_MT-169p5_powheg-pythia8/TbarWplusto4Q_MT-169p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto4Q_MT-171p5_powheg-pythia8/TbarWplusto4Q_MT-171p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto4Q_MT-171p5_powheg-pythia8/TbarWplusto4Q_MT-171p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto4Q_MT-173p5_powheg-pythia8/TbarWplusto4Q_MT-173p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto4Q_MT-173p5_powheg-pythia8/TbarWplusto4Q_MT-173p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto4Q_MT-175p5_powheg-pythia8/TbarWplusto4Q_MT-175p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto4Q_MT-175p5_powheg-pythia8/TbarWplusto4Q_MT-175p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplusto4Q_powheg-pythia8/TbarWplusto4Q_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplusto4Q_powheg-pythia8/TbarWplusto4Q_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplustoLNu2Q_DS_powheg-pythia8/TbarWplustoLNu2Q_DS_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplustoLNu2Q_DS_powheg-pythia8/TbarWplustoLNu2Q_DS_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplustoLNu2Q_Hdamp-158_powheg-pythia8/TbarWplustoLNu2Q_Hdamp-158_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplustoLNu2Q_Hdamp-158_powheg-pythia8/TbarWplustoLNu2Q_Hdamp-158_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplustoLNu2Q_Hdamp-418_powheg-pythia8/TbarWplustoLNu2Q_Hdamp-418_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplustoLNu2Q_Hdamp-418_powheg-pythia8/TbarWplustoLNu2Q_Hdamp-418_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplustoLNu2Q_MT-169p5_powheg-pythia8/TbarWplustoLNu2Q_MT-169p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplustoLNu2Q_MT-169p5_powheg-pythia8/TbarWplustoLNu2Q_MT-169p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplustoLNu2Q_MT-171p5_powheg-pythia8/TbarWplustoLNu2Q_MT-171p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplustoLNu2Q_MT-171p5_powheg-pythia8/TbarWplustoLNu2Q_MT-171p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplustoLNu2Q_MT-173p5_powheg-pythia8/TbarWplustoLNu2Q_MT-173p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplustoLNu2Q_MT-173p5_powheg-pythia8/TbarWplustoLNu2Q_MT-173p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplustoLNu2Q_MT-175p5_powheg-pythia8/TbarWplustoLNu2Q_MT-175p5_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplustoLNu2Q_MT-175p5_powheg-pythia8/TbarWplustoLNu2Q_MT-175p5_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/SingleT/TbarWplustoLNu2Q_powheg-pythia8/TbarWplustoLNu2Q_powheg-pythia8.json
+++ b/Cards/Powheg/SingleT/TbarWplustoLNu2Q_powheg-pythia8/TbarWplustoLNu2Q_powheg-pythia8.json
@@ -15,7 +15,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat","Filter/OneLepton.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto2L2Nu_Hdamp-158_powheg-pythia8/TTto2L2Nu_Hdamp-158_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto2L2Nu_Hdamp-158_powheg-pythia8/TTto2L2Nu_Hdamp-158_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto2L2Nu_Hdamp-418_powheg-pythia8/TTto2L2Nu_Hdamp-418_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto2L2Nu_Hdamp-418_powheg-pythia8/TTto2L2Nu_Hdamp-418_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto2L2Nu_MT-166p5_powheg-pythia8/TTto2L2Nu_MT-166p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto2L2Nu_MT-166p5_powheg-pythia8/TTto2L2Nu_MT-166p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto2L2Nu_MT-169p5_powheg-pythia8/TTto2L2Nu_MT-169p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto2L2Nu_MT-169p5_powheg-pythia8/TTto2L2Nu_MT-169p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto2L2Nu_MT-171p5_powheg-pythia8/TTto2L2Nu_MT-171p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto2L2Nu_MT-171p5_powheg-pythia8/TTto2L2Nu_MT-171p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto2L2Nu_MT-173p5_powheg-pythia8/TTto2L2Nu_MT-173p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto2L2Nu_MT-173p5_powheg-pythia8/TTto2L2Nu_MT-173p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto2L2Nu_MT-175p5_powheg-pythia8/TTto2L2Nu_MT-175p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto2L2Nu_MT-175p5_powheg-pythia8/TTto2L2Nu_MT-175p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto2L2Nu_MT-178p5_powheg-pythia8/TTto2L2Nu_MT-178p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto2L2Nu_MT-178p5_powheg-pythia8/TTto2L2Nu_MT-178p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto2L2Nu_powheg-pythia8/TTto2L2Nu_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto2L2Nu_powheg-pythia8/TTto2L2Nu_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto4Q_Hdamp-158_powheg-pythia8/TTto4Q_Hdamp-158_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto4Q_Hdamp-158_powheg-pythia8/TTto4Q_Hdamp-158_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto4Q_Hdamp-418_powheg-pythia8/TTto4Q_Hdamp-418_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto4Q_Hdamp-418_powheg-pythia8/TTto4Q_Hdamp-418_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto4Q_MT-166p5_powheg-pythia8/TTto4Q_MT-166p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto4Q_MT-166p5_powheg-pythia8/TTto4Q_MT-166p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto4Q_MT-169p5_powheg-pythia8/TTto4Q_MT-169p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto4Q_MT-169p5_powheg-pythia8/TTto4Q_MT-169p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto4Q_MT-171p5_powheg-pythia8/TTto4Q_MT-171p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto4Q_MT-171p5_powheg-pythia8/TTto4Q_MT-171p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto4Q_MT-173p5_powheg-pythia8/TTto4Q_MT-173p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto4Q_MT-173p5_powheg-pythia8/TTto4Q_MT-173p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto4Q_MT-175p5_powheg-pythia8/TTto4Q_MT-175p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto4Q_MT-175p5_powheg-pythia8/TTto4Q_MT-175p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto4Q_MT-178p5_powheg-pythia8/TTto4Q_MT-178p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto4Q_MT-178p5_powheg-pythia8/TTto4Q_MT-178p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTto4Q_powheg-pythia8/TTto4Q_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTto4Q_powheg-pythia8/TTto4Q_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTtoLNu2Q_Hdamp-158_powheg-pythia8/TTtoLNu2Q_Hdamp-158_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTtoLNu2Q_Hdamp-158_powheg-pythia8/TTtoLNu2Q_Hdamp-158_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTtoLNu2Q_Hdamp-418_powheg-pythia8/TTtoLNu2Q_Hdamp-418_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTtoLNu2Q_Hdamp-418_powheg-pythia8/TTtoLNu2Q_Hdamp-418_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTtoLNu2Q_MT-166p5_powheg-pythia8/TTtoLNu2Q_MT-166p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTtoLNu2Q_MT-166p5_powheg-pythia8/TTtoLNu2Q_MT-166p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTtoLNu2Q_MT-169p5_powheg-pythia8/TTtoLNu2Q_MT-169p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTtoLNu2Q_MT-169p5_powheg-pythia8/TTtoLNu2Q_MT-169p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTtoLNu2Q_MT-171p5_powheg-pythia8/TTtoLNu2Q_MT-171p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTtoLNu2Q_MT-171p5_powheg-pythia8/TTtoLNu2Q_MT-171p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTtoLNu2Q_MT-173p5_powheg-pythia8/TTtoLNu2Q_MT-173p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTtoLNu2Q_MT-173p5_powheg-pythia8/TTtoLNu2Q_MT-173p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTtoLNu2Q_MT-175p5_powheg-pythia8/TTtoLNu2Q_MT-175p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTtoLNu2Q_MT-175p5_powheg-pythia8/TTtoLNu2Q_MT-175p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTtoLNu2Q_MT-178p5_powheg-pythia8/TTtoLNu2Q_MT-178p5_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTtoLNu2Q_MT-178p5_powheg-pythia8/TTtoLNu2Q_MT-178p5_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/TT/TTtoLNu2Q_powheg-pythia8/TTtoLNu2Q_powheg-pythia8.json
+++ b/Cards/Powheg/TT/TTtoLNu2Q_powheg-pythia8/TTtoLNu2Q_powheg-pythia8.json
@@ -14,7 +14,7 @@
     ],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/WW/WWto2L2Nu_powheg-pythia8/WWto2L2Nu_powheg-pythia8.json
+++ b/Cards/Powheg/WW/WWto2L2Nu_powheg-pythia8/WWto2L2Nu_powheg-pythia8.json
@@ -9,7 +9,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/WW/WWto4Q_powheg-pythia8/WWto4Q_powheg-pythia8.json
+++ b/Cards/Powheg/WW/WWto4Q_powheg-pythia8/WWto4Q_powheg-pythia8.json
@@ -9,7 +9,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/WW/WWtoLNu2Q_powheg-pythia8/WWtoLNu2Q_powheg-pythia8.json
+++ b/Cards/Powheg/WW/WWtoLNu2Q_powheg-pythia8/WWtoLNu2Q_powheg-pythia8.json
@@ -9,7 +9,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/WZ/WZto2L2Q_powheg-pythia8/WZto2L2Q_powheg-pythia8.json
+++ b/Cards/Powheg/WZ/WZto2L2Q_powheg-pythia8/WZto2L2Q_powheg-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/WZ/WZto3LNu_powheg-pythia8/WZto3LNu_powheg-pythia8.json
+++ b/Cards/Powheg/WZ/WZto3LNu_powheg-pythia8/WZto3LNu_powheg-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/WZ/WZtoLNu2Q_powheg-pythia8/WZtoLNu2Q_powheg-pythia8.json
+++ b/Cards/Powheg/WZ/WZtoLNu2Q_powheg-pythia8/WZtoLNu2Q_powheg-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/ZZ/ZZto2L2Nu_powheg-pythia8/ZZto2L2Nu_powheg-pythia8.json
+++ b/Cards/Powheg/ZZ/ZZto2L2Nu_powheg-pythia8/ZZto2L2Nu_powheg-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/ZZ/ZZto2L2Q_powheg-pythia8/ZZto2L2Q_powheg-pythia8.json
+++ b/Cards/Powheg/ZZ/ZZto2L2Q_powheg-pythia8/ZZto2L2Q_powheg-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/ZZ/ZZto2Nu2Q_powheg-pythia8/ZZto2Nu2Q_powheg-pythia8.json
+++ b/Cards/Powheg/ZZ/ZZto2Nu2Q_powheg-pythia8/ZZto2Nu2Q_powheg-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Cards/Powheg/ZZ/ZZto4L_powheg-pythia8/ZZto4L_powheg-pythia8.json
+++ b/Cards/Powheg/ZZ/ZZto4L_powheg-pythia8/ZZto4L_powheg-pythia8.json
@@ -10,7 +10,7 @@
     "model_params_user": [],
     "model_params_vars": {},
     
-    "fragment": ["Generator/ExternalLHEProducer.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
+    "fragment": ["Generator/ExternalLHEProducer_Powheg.dat","PartonShower/PowhegEmissionVetoPythia8.dat"],
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [

--- a/Validation/README.md
+++ b/Validation/README.md
@@ -23,9 +23,9 @@ If above arguments are not given, `NEVENTS` will be set to `(CROSS_SECTION) X 50
 
 ## Forging PREPIDs (and cloning PREPIDs)
 
-``./forge_prepids.py <PICKLEFILE> -g GENERATOR``
+``./forge_prepids.py <PICKLEFILE> ``
 
-``#./forge_prepids.py QCDB/prepids.pickle -g MadGraph5_aMCatNLO``
+``#./forge_prepids.py QCDB/prepids.pickle ``
 
 This script will collect the parsed `PREPID` inputs and modify, clone requests for "Run3Summer22wmLHEGS" and "Run3Summer22EEwmLHEGS". `NEVENTS` will be multipled by "3.5" for "Run3Summer22EEwmLHEGS".
 

--- a/Validation/README.md
+++ b/Validation/README.md
@@ -32,4 +32,3 @@ This script will collect the parsed `PREPID` inputs and modify, clone requests f
 ## Long term fixes to be done
 
 - `parse_jobs.py` : NEVENTS should be computed with various campaigns and luminosities rather than the fixed value "50000 /pb".
-- `forge_prepids.py` : GENERATOR should be given at the stage where from the extravaganza machinery, not here.

--- a/Validation/forge_prepids.py
+++ b/Validation/forge_prepids.py
@@ -22,11 +22,6 @@ def parse_arguments() :
                         action="store",\
                         help = "pickle file to submit to mcm")
 
-    # should ask geovanny to add this automatically #FIXME
-    parser.add_argument("-g", "--generator", required=True,\
-                        action="store",\
-                        help = "generator used for the sample")
-
     return parser.parse_args()
 
 def edit_prepid(data) :


### PR DESCRIPTION
This PR is to adapt the cards to use the externalLHEProducer cards corresponding to each generator.

I've just used the `sed` command to change all occurences of `ExternalLHEProducer` to `ExternalLHEProducer_MadGraph5_aMCatNLO` (for processes inside Madgraph5_aMCatNLO folder) and `ExternalLHEProducer_Powheg` (for processes inside Powheg folder). 

Edit:
I've also added another commit that removes the `-g` option from the `forge_prepids.py` script.