### PR TITLE
Cards for TT-2Jets FxFx

### DIFF
--- a/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8.json
@@ -15,7 +15,7 @@
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [
-            "'JetMatching:qCut = 42.'",
+            "'JetMatching:qCut = 40.'",
             "'JetMatching:qCutME = 20.'",
             "'JetMatching:nQmatch = 5'",
             "'JetMatching:nJetMax = 2'",

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8.json
@@ -4,7 +4,7 @@
     "template_vars":{
         "parton_shower": "pythia8",
         "ickkw": "3",
-        "maxjetflavor": "5",
+        "maxjetflavor": "5"
     },
     "model_params": "massW.dat",
     "model_params_user": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8.json
@@ -1,0 +1,26 @@
+{
+    "template": "NLO_run_card.dat",
+    "template_user": [],
+    "template_vars":{
+        "parton_shower": "pythia8",
+        "ickkw": "3",
+        "maxjetflavor": "5",
+    },
+    "model_params": "massW.dat",
+    "model_params_user": [
+        "set run_card ptj 20"
+    ],
+    "model_params_vars": {},
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment_user": [],
+    "fragment_vars": {
+        "processParameters": [
+            "'JetMatching:qCut = 42.'",
+            "'JetMatching:qCutME = 20.'",
+            "'JetMatching:nQmatch = 5'",
+            "'JetMatching:nJetMax = 2'",
+            "'TimeShower:mMaxGamma = 4.0'"
+        ]
+    }
+}
+

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8_madspin_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8_madspin_card.dat
@@ -1,0 +1,13 @@
+#directory for gridpack mode
+set ms_dir ./madspingrid
+
+#initialization parameters
+set Nevents_for_max_weight 250 # number of events for the estimate of the max. weight
+set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+
+set max_running_process 1
+
+decay t > w+ b, w+ > ell+ vl
+decay t~ > w- b~, w- > ell- vl~
+
+launch

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8_proc_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8_proc_card.dat
@@ -5,9 +5,6 @@ define ell- = e- mu- ta-
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 
-define p = p b b~
-define j = j b b~
-
 generate p p > t t~ [QCD] @0
 add process p p > t t~ j [QCD] @1
 add process p p > t t~ j j [QCD] @2

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8_proc_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8/TTto2L2Nu-2Jets_amcatnloFXFX-pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+import model loop_sm-ckm_no_b_mass
+
+define ell+ = e+ mu+ ta+
+define ell- = e- mu- ta-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+
+define p = p b b~
+define j = j b b~
+
+generate p p > t t~ [QCD] @0
+add process p p > t t~ j [QCD] @1
+add process p p > t t~ j j [QCD] @2
+
+output TTto2L2Nu-2Jets_amcatnloFXFX-pythia8 -nojpeg

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8.json
@@ -15,7 +15,7 @@
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [
-            "'JetMatching:qCut = 42.'",
+            "'JetMatching:qCut = 40.'",
             "'JetMatching:qCutME = 20.'",
             "'JetMatching:nQmatch = 5'",
             "'JetMatching:nJetMax = 2'",

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8.json
@@ -4,7 +4,7 @@
     "template_vars":{
         "parton_shower": "pythia8",
         "ickkw": "3",
-        "maxjetflavor": "5",
+        "maxjetflavor": "5"
     },
     "model_params": "massW.dat",
     "model_params_user": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8.json
@@ -1,0 +1,26 @@
+{
+    "template": "NLO_run_card.dat",
+    "template_user": [],
+    "template_vars":{
+        "parton_shower": "pythia8",
+        "ickkw": "3",
+        "maxjetflavor": "5",
+    },
+    "model_params": "massW.dat",
+    "model_params_user": [
+        "set run_card ptj 20"
+    ],
+    "model_params_vars": {},
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment_user": [],
+    "fragment_vars": {
+        "processParameters": [
+            "'JetMatching:qCut = 42.'",
+            "'JetMatching:qCutME = 20.'",
+            "'JetMatching:nQmatch = 5'",
+            "'JetMatching:nJetMax = 2'",
+            "'TimeShower:mMaxGamma = 4.0'"
+        ]
+    }
+}
+

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8_madspin_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8_madspin_card.dat
@@ -1,0 +1,13 @@
+#directory for gridpack mode
+set ms_dir ./madspingrid
+
+#initialization parameters
+set Nevents_for_max_weight 250 # number of events for the estimate of the max. weight
+set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+
+set max_running_process 1
+
+decay t > w+ b, w+ > j j 
+decay t~ > w- b~, w- > j j
+
+launch

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
@@ -5,9 +5,6 @@ define ell- = e- mu- ta-
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 
-define p = p b b~
-define j = j b b~
-
 generate p p > t t~ [QCD] @0
 add process p p > t t~ j [QCD] @1
 add process p p > t t~ j j [QCD] @2

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-2Jets_amcatnloFXFX-pythia8/TTto4Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+import model loop_sm-ckm_no_b_mass
+
+define ell+ = e+ mu+ ta+
+define ell- = e- mu- ta-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+
+define p = p b b~
+define j = j b b~
+
+generate p p > t t~ [QCD] @0
+add process p p > t t~ j [QCD] @1
+add process p p > t t~ j j [QCD] @2
+
+output TTto4Q-2Jets_amcatnloFXFX-pythia8 -nojpeg

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8.json
@@ -15,7 +15,7 @@
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [
-            "'JetMatching:qCut = 42.'",
+            "'JetMatching:qCut = 40.'",
             "'JetMatching:qCutME = 20.'",
             "'JetMatching:nQmatch = 5'",
             "'JetMatching:nJetMax = 2'",

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8.json
@@ -4,7 +4,7 @@
     "template_vars":{
         "parton_shower": "pythia8",
         "ickkw": "3",
-        "maxjetflavor": "5",
+        "maxjetflavor": "5"
     },
     "model_params": "massW.dat",
     "model_params_user": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8.json
@@ -1,0 +1,26 @@
+{
+    "template": "NLO_run_card.dat",
+    "template_user": [],
+    "template_vars":{
+        "parton_shower": "pythia8",
+        "ickkw": "3",
+        "maxjetflavor": "5",
+    },
+    "model_params": "massW.dat",
+    "model_params_user": [
+        "set run_card ptj 20"
+    ],
+    "model_params_vars": {},
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment_user": [],
+    "fragment_vars": {
+        "processParameters": [
+            "'JetMatching:qCut = 42.'",
+            "'JetMatching:qCutME = 20.'",
+            "'JetMatching:nQmatch = 5'",
+            "'JetMatching:nJetMax = 2'",
+            "'TimeShower:mMaxGamma = 4.0'"
+        ]
+    }
+}
+

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8_madspin_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8_madspin_card.dat
@@ -1,0 +1,13 @@
+#directory for gridpack mode
+set ms_dir ./madspingrid
+
+#initialization parameters
+set Nevents_for_max_weight 250 # number of events for the estimate of the max. weight
+set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+
+set max_running_process 1
+
+decay t > w+ b, w+ > j j 
+decay t~ > w- b~, w- > ell- vl~
+
+launch

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
@@ -5,9 +5,6 @@ define ell- = e- mu- ta-
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 
-define p = p b b~
-define j = j b b~
-
 generate p p > t t~ [QCD] @0
 add process p p > t t~ j [QCD] @1
 add process p p > t t~ j j [QCD] @2

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+import model loop_sm-ckm_no_b_mass
+
+define ell+ = e+ mu+ ta+
+define ell- = e- mu- ta-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+
+define p = p b b~
+define j = j b b~
+
+generate p p > t t~ [QCD] @0
+add process p p > t t~ j [QCD] @1
+add process p p > t t~ j j [QCD] @2
+
+output TTtoLminusNu2Q-2Jets_amcatnloFXFX-pythia8 -nojpeg

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8.json
@@ -15,7 +15,7 @@
     "fragment_user": [],
     "fragment_vars": {
         "processParameters": [
-            "'JetMatching:qCut = 42.'",
+            "'JetMatching:qCut = 40.'",
             "'JetMatching:qCutME = 20.'",
             "'JetMatching:nQmatch = 5'",
             "'JetMatching:nJetMax = 2'",

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8.json
@@ -4,7 +4,7 @@
     "template_vars":{
         "parton_shower": "pythia8",
         "ickkw": "3",
-        "maxjetflavor": "5",
+        "maxjetflavor": "5"
     },
     "model_params": "massW.dat",
     "model_params_user": [

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8.json
@@ -1,0 +1,26 @@
+{
+    "template": "NLO_run_card.dat",
+    "template_user": [],
+    "template_vars":{
+        "parton_shower": "pythia8",
+        "ickkw": "3",
+        "maxjetflavor": "5",
+    },
+    "model_params": "massW.dat",
+    "model_params_user": [
+        "set run_card ptj 20"
+    ],
+    "model_params_vars": {},
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat"],
+    "fragment_user": [],
+    "fragment_vars": {
+        "processParameters": [
+            "'JetMatching:qCut = 42.'",
+            "'JetMatching:qCutME = 20.'",
+            "'JetMatching:nQmatch = 5'",
+            "'JetMatching:nJetMax = 2'",
+            "'TimeShower:mMaxGamma = 4.0'"
+        ]
+    }
+}
+

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8_madspin_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8_madspin_card.dat
@@ -1,0 +1,13 @@
+#directory for gridpack mode
+set ms_dir ./madspingrid
+
+#initialization parameters
+set Nevents_for_max_weight 250 # number of events for the estimate of the max. weight
+set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+
+set max_running_process 1
+
+decay t > w+ b, w+ > ell+ vl
+decay t~ > w- b~, w- > j j 
+
+launch

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+import model loop_sm-ckm_no_b_mass
+
+define ell+ = e+ mu+ ta+
+define ell- = e- mu- ta-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+
+define p = p b b~
+define j = j b b~
+
+generate p p > t t~ [QCD] @0
+add process p p > t t~ j [QCD] @1
+add process p p > t t~ j j [QCD] @2
+
+output TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8 -nojpeg

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8/TTtoLplusNu2Q-2Jets_amcatnloFXFX-pythia8_proc_card.dat
@@ -5,9 +5,6 @@ define ell- = e- mu- ta-
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 
-define p = p b b~
-define j = j b b~
-
 generate p p > t t~ [QCD] @0
 add process p p > t t~ j [QCD] @1
 add process p p > t t~ j j [QCD] @2


### PR DESCRIPTION
PR with the cards for TT aMC@nlo fxfx sample.

**Important:** I've chosen qCut = 42 to keep it consistent with other FxFx TOP samples (Run2 used 40 according to the requests in McM). I think this is reasonable but let's hear more opinions. Just FYI: the LO TT sample (3jets) had qcut of 70.