### PR TITLE
Preliminary stuff for herwig

### DIFF
--- a/Cards/Powheg/NewTests/TWminustoLNu2Q_powheg-herwig7/TWminustoLNu2Q_powheg-herwig7.json
+++ b/Cards/Powheg/NewTests/TWminustoLNu2Q_powheg-herwig7/TWminustoLNu2Q_powheg-herwig7.json
@@ -1,0 +1,11 @@
+{
+    "gridpack_submit": false,
+    "gridpack_path": "SingleT/ST_wtch_DR_slc7_amd64_gcc10_CMSSW_12_4_8_TWminustoLNu2Q_powheg-pythia8.tgz",
+
+    "fragment": ["Generator/ExternalLHEProducer_Powheg-herwig7.dat","PartonShower/powheg-herwig7.dat","Filter/OneLepton.dat"],
+    "fragment_user": [],
+    "fragment_vars": {
+        "processParameters": [
+        ]
+    }
+}

--- a/Fragments/Generator/ExternalLHEProducer_Powheg-herwig7.dat
+++ b/Fragments/Generator/ExternalLHEProducer_Powheg-herwig7.dat
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('$pathToProducedGridpack'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool($concurrentLHEforPowheg)
+    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
+)
+

--- a/Fragments/PartonShower/powheg-herwig7.dat
+++ b/Fragments/PartonShower/powheg-herwig7.dat
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Herwig7Settings.Herwig7LHECommonSettings_cfi import *
+from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_cfi import *
+from Configuration.Generator.Herwig7Settings.Herwig7CH3TuneSettings_cfi import *
+from Configuration.Generator.Herwig7Settings.Herwig7LHEPowhegSettings_cfi import *
+from Configuration.Generator.Herwig7Settings.Herwig7PSWeightsSettings_cfi import *
+from Configuration.Generator.Herwig7Settings.Herwig7_7p1SettingsFor7p2_cfi import *
+
+generator = cms.EDFilter("Herwig7GeneratorFilter",
+    herwig7LHECommonSettingsBlock,
+    herwig7LHEPowhegSettingsBlock,
+    herwig7p1SettingsFor7p2Block,
+    herwig7StableParticlesForDetectorBlock,
+    herwig7PSWeightsSettingsBlock,
+    herwig7CH3SettingsBlock,
+    configFiles = cms.vstring(),
+    dataLocation = cms.string('${HERWIGPATH}'),
+    eventHandlers = cms.string('/Herwig/EventHandlers'),
+    generatorModule = cms.string('/Herwig/Generators/EventGenerator'),    
+    hw_user_settings = cms.vstring(
+        'set /Herwig/EventHandlers/EventHandler:LuminosityFunction:Energy $comEnergy*GeV',
+        $processParameters
+    ),     
+    parameterSets = cms.vstring(
+        'hw_lhe_common_settings',
+        'hw_lhe_powheg_settings',
+        'hw_7p1SettingsFor7p2',
+        'herwig7CH3PDF', 
+        'herwig7CH3AlphaS', 
+        'herwig7CH3MPISettings', 
+        'herwig7StableParticlesForDetector',
+        'hw_PSWeights_settings',
+        'hw_user_settings'
+    ),
+    repository = cms.string('${HERWIGPATH}/HerwigDefaults.rpo'),
+    run = cms.string('InterfaceMatchboxTest'),
+    runModeList = cms.untracked.string('read,run'),
+)


### PR DESCRIPTION
Hi,

This is just a preliminary version of herwig config files for central herwig samples. There's no particular rush I think in having this implement in a short timescale, but I'm leaving the PR open just to have this in mind in the future. This might take a bit of time because if I'm not mistaken, it would require a bit of development in the backend.

I think there are a few things to discuss:

- **ExternalProducer**: herwig requires to launch an script that merges lhe files before starting the shower step. This can be seen in the `    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),` option in `ExternalLHEProducer_Powheg-herwig7.dat`.
- **Fragment**: There are a few things to mention here.
  - Center of mass energy and processParameters (which for herwig are often specific commands of herwig) can be configured using the same placeholders as for pythia8.     
  - I haven't found out what is the option `configFiles = cms.vstring()` in the fragment. Seems to me that this is to allow people to configure herwig commands using an input file that is a ".in" format. See the **only** example in cmssw that does not set this to just an empty variable [here](https://github.com/cms-sw/cmssw/blob/245daa4d7ad8e1412084c2d66381edfd8835d7ad/GeneratorInterface/Herwig7Interface/python/Herwig7_Dummy_ConfigFile_cff.py#L10). This config points to [this file](https://github.com/cms-sw/cmssw/blob/245daa4d7ad8e1412084c2d66381edfd8835d7ad/GeneratorInterface/Herwig7Interface/test/LHC-Matchbox.in#L155).
- **Input process**. I think for herwig samples we should have the mindset that by default these are variations of our commonly pythia8 showered samples. I've create the example I'm working now within TOP to test once the backend is set to consider herwig showers.