### PR TITLE
Add tt genMet filter

### DIFF
--- a/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-3Jets_genMET-150_madgraphMLM-pythia8/TTto2L2Nu-3Jets_genMET-150_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto2L2Nu-3Jets_genMET-150_madgraphMLM-pythia8/TTto2L2Nu-3Jets_genMET-150_madgraphMLM-pythia8.json
@@ -1,0 +1,15 @@
+{
+    "gridpack_submit": false,
+    "gridpack_path" : "TT/TTto2L2Nu-3Jets_genMET-150_madgraphMLM-pythia8",
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8-hepmcfilter.dat", "Filter/LHE_genMET150_filter.dat"],
+    "fragment_user": [],
+    "fragment_vars": {
+        "processParameters": [
+            "'JetMatching:qCut = 70.'",
+            "'JetMatching:nQmatch = 5'",
+            "'JetMatching:nJetMax = 3'",
+            "'TimeShower:mMaxGamma = 4.0'"
+        ]
+    }
+}
+

--- a/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-3Jets_genMET-150_madgraphMLM-pythia8/TTto4Q-3Jets_genMET-150_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTto4Q-3Jets_genMET-150_madgraphMLM-pythia8/TTto4Q-3Jets_genMET-150_madgraphMLM-pythia8.json
@@ -1,0 +1,16 @@
+    
+{
+    "gridpack_submit": false,
+    "gridpack_path" : "TT/TTto4Q-3Jets_madgraphMLM-pythia8",
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8-hepmcfilter.dat", "Filter/LHE_genMET150_filter.dat"],
+    "fragment_user": [],
+    "fragment_vars": {
+        "processParameters": [
+            "'JetMatching:qCut = 70.'",
+            "'JetMatching:nQmatch = 5'",
+            "'JetMatching:nJetMax = 3'",
+            "'TimeShower:mMaxGamma = 4.0'"
+        ]
+    }
+}
+

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-3Jets_genMET-150_madgraphMLM-pythia8/TTtoLminusNu2Q-3Jets_genMET-150_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLminusNu2Q-3Jets_genMET-150_madgraphMLM-pythia8/TTtoLminusNu2Q-3Jets_genMET-150_madgraphMLM-pythia8.json
@@ -1,0 +1,15 @@
+{
+    "gridpack_submit": false,
+    "gridpack_path" : "TT/TTtoLminusNu2Q-3Jets_madgraphMLM-pythia8",
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8-hepmcfilter.dat", "Filter/LHE_genMET150_filter.dat"],
+    "fragment_user": [],
+    "fragment_vars": {
+        "processParameters": [
+            "'JetMatching:qCut = 70.'",
+            "'JetMatching:nQmatch = 5'",
+            "'JetMatching:nJetMax = 3'",
+            "'TimeShower:mMaxGamma = 4.0'"
+        ]
+    }
+}
+

--- a/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-3Jets_genMET-150_madgraphMLM-pythia8/TTtoLplusNu2Q-3Jets_genMET-150_madgraphMLM-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTtoLplusNu2Q-3Jets_genMET-150_madgraphMLM-pythia8/TTtoLplusNu2Q-3Jets_genMET-150_madgraphMLM-pythia8.json
@@ -1,0 +1,15 @@
+{
+    "gridpack_submit": false,
+    "gridpack_path" : "TTtoLplusNu2Q-3Jets_madgraphMLM-pythia8",
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/madgraphMLM-pythia8-hepmcfilter.dat", "Filter/LHE_genMET150_filter.dat"],
+    "fragment_user": [],
+    "fragment_vars": {
+        "processParameters": [
+            "'JetMatching:qCut = 70.'",
+            "'JetMatching:nQmatch = 5'",
+            "'JetMatching:nJetMax = 3'",
+            "'TimeShower:mMaxGamma = 4.0'"
+        ]
+    }
+}
+

--- a/Fragments/Filter/LHE_genMET150_filter.dat
+++ b/Fragments/Filter/LHE_genMET150_filter.dat
@@ -1,0 +1,35 @@
+tmpGenParticlesForJetsNoNu = cms.EDProducer("InputGenJetsParticleSelector",
+    src = cms.InputTag("tmpGenParticles"),
+    ignoreParticleIDs = cms.vuint32(12,14,16),
+    partonicFinalState = cms.bool(False),
+    excludeResonances = cms.bool(False),
+    excludeFromResonancePids = cms.vuint32(12, 13, 14, 16),
+    tausAsJets = cms.bool(False)
+)
+
+tmpGenMetTrue = cms.EDProducer("GenMETProducer",
+                               src = cms.InputTag("tmpGenParticlesForJetsNoNu"),
+                               alias = cms.string('GenMETAllVisible'), 
+                               onlyFiducialParticles = cms.bool(False),
+                               globalThreshold = cms.double(0.0),
+                               usePt   = cms.bool(True),
+                               applyFiducialThresholdForFractions = cms.bool(False),
+)
+
+genMETfilter1 = cms.EDFilter("CandViewSelector",
+   src = cms.InputTag("tmpGenMetTrue"),
+   cut = cms.string("pt > 150")
+)
+
+genMETfilter2 = cms.EDFilter("CandViewCountFilter",
+    src = cms.InputTag("genMETfilter1"),
+    minNumber = cms.uint32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator*
+                                        tmpGenParticles*
+                                        tmpGenParticlesForJetsNoNu *
+                                        tmpGenMetTrue* 
+                                        genMETfilter1* 
+                                        genMETfilter2
+)


### PR DESCRIPTION
- Reuse gridpacks on TT madgraph MLM 
- Cleaned the genMET that was previously considering particle IDs related to SUSY models.
- Reference request for the filters: https://cms-pdmv-prod.web.cern.ch/mcm/edit?db_name=requests&prepid=TOP-RunIISummer20UL18wmLHEGEN-00264&page=0