### PR TITLE
use oidc for the authentication mechanism

### DIFF
--- a/Validation/forge_prepids.py
+++ b/Validation/forge_prepids.py
@@ -9,7 +9,7 @@ import argparse
 sys.path.append('/afs/cern.ch/cms/PPD/PdmV/tools/McM/')
 from rest import *
 
-mcm = McM(dev=False)
+mcm = McM(dev=False,id=McM.OIDC)
 
 CLONE_TARGETS = {
     "Run3Summer22EEwmLHEGS" : 3.5,


### PR DESCRIPTION
When 2FA is enabled, "oidc" should be used as the authentication mechanism.