### PR TITLE
TTZ-ZtoBB

### DIFF
--- a/Cards/MadGraph5_aMCatNLO/TT/TTZ-ZtoBB-1Jets_amcatnloFXFX-pythia8/TTZ-ZtoBB-1Jets_amcatnloFXFX-pythia8.json
+++ b/Cards/MadGraph5_aMCatNLO/TT/TTZ-ZtoBB-1Jets_amcatnloFXFX-pythia8/TTZ-ZtoBB-1Jets_amcatnloFXFX-pythia8.json
@@ -1,0 +1,15 @@
+{
+    "gridpack_submit": false,
+    "gridpack_path" : "TT/TTZ-ZtoQQ-1Jets_amcatnloFXFX-pythia8_slc7_amd64_gcc10_CMSSW_12_4_8_tarball.tar.xz", 
+    "fragment": ["Generator/ExternalLHEProducer_MadGraph5_aMCatNLO.dat", "PartonShower/amcatnloFXFX-pythia8.dat", "Filter/LHE_onlyB_filter.dat"],
+    "fragment_user": [],
+    "fragment_vars": {
+        "processParameters": [
+            "'JetMatching:qCut = 42.'",
+            "'JetMatching:qCutME = 20.'",
+            "'JetMatching:nQmatch = 5'",
+            "'JetMatching:nJetMax = 1'",
+            "'TimeShower:mMaxGamma = 4.0'"
+        ]
+    }
+}

--- a/Fragments/Filter/LHE_onlyB_filter.dat
+++ b/Fragments/Filter/LHE_onlyB_filter.dat
@@ -1,0 +1,8 @@
+LHE_onlyB_filter = cms.EDFilter("LHEGenericFilter",
+    src = cms.InputTag("externalLHEProducer"),
+    NumRequired = cms.int32(0),
+    ParticleID = cms.vint32([1,2,3,4]),
+    AcceptLogic = cms.string("EQ") # LT meaning < NumRequired, GT >, EQ =, NE !=
+)
+
+ProductionFilterSequence = cms.Sequence(generator*LHE_onlyB_filter)


### PR DESCRIPTION
We've been requested to make ttZ ZtoBB enriched samples, based on the ttZ-ZtoQQ samples that we already have. The PR includes the json file for ttZ-ZtoQQ reuse of gridpack, and also a filter for the fragment that selects only events that do not have d, c, u or s quarks in the LHE.

do you think this is a good approach?